### PR TITLE
Update client.py

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -157,8 +157,20 @@ class Spotify(object):
             Parameters:
                 - result - a previously returned paged result
         '''
-        if result['next']:
-            return self._get(result['next'])
+        from re import sub
+
+        if (result['limit'] + result['offset']) < result['total']:
+            # get new offset
+            offset = 'offset={}'.format(result['limit'] + result['offset'])
+            
+            # update or add offset to result's href string
+            if 'offset' in result['href']:
+                href = sub('offset=([0-9]+)', offset, result['href'])
+            else:
+                href = '&'.join(result['href'], offset)
+
+            # call updated href string
+            return self._get(href)
         else:
             return None
 
@@ -288,7 +300,7 @@ class Spotify(object):
         tlist = [self._get_id('album', a) for a in albums]
         return self._get('albums/?ids=' + ','.join(tlist))
 
-    def search(self, q, limit=10, offset=0, type='track'):
+    def search(self, q, limit=10, offset=0, type='track', market=None):
         ''' searches for an item
 
             Parameters:
@@ -297,8 +309,10 @@ class Spotify(object):
                 - offset - the index of the first item to return
                 - type - the type of item to return. One of 'artist', 'album',
                          'track' or 'playlist'
+                - market - the market results should be limited to
         '''
-        return self._get('search', q=q, limit=limit, offset=offset, type=type)
+        return self._get('search', q=q, limit=limit, offset=offset, type=type, 
+                         market=market)
 
     def user(self, user):
         ''' Gets basic profile information about a Spotify User


### PR DESCRIPTION
`.next()` would not load the next page of results using a `while True...result = spotify.next(result)`. This has been updated to determine if `limit + offset` is less than `total`, if so, update `result['href']` with the new `offset`.

```python
sp = spotipy.Spotify()

def get_albums(artist, locale=None):
    artist = 'artist:{}'.format(artist)
    result = sp.search(q=artist, type='album', limit=10, market=locale)
    
    while True:
        print len(result['albums']['items'])
        
        result = sp.next(result['albums'])

        if result is None:
            break
```

`market` was also added as an argument in `.search` as the API allows to search in a specific market.